### PR TITLE
fix pylint complaints about use of super() on django.db.models.Manager

### DIFF
--- a/pylint_django/transforms/__init__.py
+++ b/pylint_django/transforms/__init__.py
@@ -57,7 +57,9 @@ _add_transform('django.forms.fields',
                )
 _add_transform('django.forms', 'Form')
 _add_transform('django.forms', 'ModelForm')
-_add_transform('django.db.models', 'Model')
+_add_transform('django.db.models',
+               'Model',
+               'Manager')
 _add_transform('django.db.models.fields',
                'BigIntegerField',
                'BooleanField',

--- a/pylint_django/transforms/transforms/django_db_models.py
+++ b/pylint_django/transforms/transforms/django_db_models.py
@@ -7,3 +7,8 @@ class Model(object):
 
     MultipleObjectsReturned = None
     DoesNotExist = None
+
+
+# eliminate E1002 for Manager object
+class Manager(object):
+    pass


### PR DESCRIPTION
... subclasses. This is done by exposing a Manager object.
see https://github.com/treyhunner/django-simple-history/pull/134 as well.