### PR TITLE
Add support for more rest_framework classes, and django_filters

### DIFF
--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -162,7 +162,11 @@ def is_model_meta_subclass(node):
     parents = ('django.db.models.base.Model',
                'django.forms.forms.Form',
                'django.forms.models.ModelForm',
-               'rest_framework.serializers.ModelSerializer')
+               'rest_framework.serializers.ModelSerializer',
+               'rest_framework.generics.GenericAPIView',
+               'rest_framework.viewsets.ReadOnlyModelViewSet',
+               'rest_framework.viewsets.ModelViewSet',
+               'django_filters.filterset.FilterSet',)
     return any([node_is_subclass(node.parent, parent) for parent in parents])
 
 


### PR DESCRIPTION
A previous PR added support for Django Rest Framework Meta classes, but only within serializers. Meta classes actually occur in many other places within code using DRF, so this PR expands this list to cover (hopefully) all of those.