### PR TITLE
Fix travis builds

### DIFF
--- a/pylint_django/transforms/__init__.py
+++ b/pylint_django/transforms/__init__.py
@@ -26,7 +26,11 @@ def _add_transform(package_name, *class_names):
         if module.name != package_name:
             return
         for class_name in class_names:
-            module._locals[class_name] = fake._locals[class_name]  # pylint: disable=protected-access
+            # This changed from locals to _locals between astroid 1.3 and 1.4
+            if hasattr(module, '_locals'):
+                module._locals[class_name] = fake._locals[class_name]  # pylint: disable=protected-access
+            else:
+                module.locals[class_name] = fake.locals[class_name]
 
     MANAGER.register_transform(nodes.Module, set_fake_locals)
 

--- a/test/test_func.py
+++ b/test/test_func.py
@@ -1,5 +1,6 @@
 
 import os
+import sys
 import unittest
 from django.conf import settings
 from pylint.testutils import make_tests, LintTestUsingFile, cb_test_gen, linter
@@ -12,6 +13,11 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 
 linter.load_plugin_modules(['pylint_django'])
+# Disable some things on Python2.6, since we use a different pylint version here
+# (1.3 on Python2.6, 1.4+ on later versions)
+if sys.version_info < (2, 7):
+    linter.global_set_option('required-attributes', ())
+    linter.global_set_option('disable', ('E0012',))
 
 
 def module_exists(module_name):


### PR DESCRIPTION
The Travis build for Python2.6 was broken due to changes in astroid and deprecated options in pylint. I fixed both :)