### PR TITLE
transforms: extend _locals instead of replacing it

### DIFF
--- a/pylint_django/transforms/__init__.py
+++ b/pylint_django/transforms/__init__.py
@@ -26,7 +26,7 @@ def _add_transform(package_name, *class_names):
         if module.name != package_name:
             return
         for class_name in class_names:
-            module._locals[class_name] = fake._locals[class_name]  # pylint: disable=protected-access
+            module._locals[class_name].extend(fake._locals[class_name])  # pylint: disable=protected-access
 
     MANAGER.register_transform(nodes.Module, set_fake_locals)
 

--- a/test/input/func_noerror_model_methods.py
+++ b/test/input/func_noerror_model_methods.py
@@ -1,0 +1,16 @@
+"""
+Checks that Pylint does not complain about using Model and Manager methods
+"""
+#  pylint: disable=C0111,W5101,W5103
+from django.db import models
+
+
+class SomeModel(models.Model):
+    pass
+
+if __name__ == '__main__':
+    MODEL = SomeModel()
+    MODEL.save()
+    MODEL.delete()
+
+    COUNT = SomeModel.objects.count()


### PR DESCRIPTION
this way we don't clobber existing locals, something that the new test demonstrates.
previously, calls to save() and delete() on a model instance caused a pylint error.

The remaining travis build errors are handled in #57 - I'll update this one once that is merged :)