### PR TITLE
fix E1101 problem when use mongoengine.Document.objects as a query.

### DIFF
--- a/pylint_django/transforms/transforms/mongoengine.py
+++ b/pylint_django/transforms/transforms/mongoengine.py
@@ -1,8 +1,9 @@
 from mongoengine.errors import DoesNotExist, MultipleObjectsReturned
+from mongoengine.queryset.manager import QuerySetManager
 
 class Document(object):
     _meta = None
-    objects = None
+    objects = QuerySetManager()
 
     id = None
     pk = None


### PR DESCRIPTION
By set .objects to a QuerySetManager instance.