### PR TITLE
Add json field to WSGIRequest proxy

### DIFF
--- a/pylint_django/transforms/transforms/django_core_handlers_wsgi.py
+++ b/pylint_django/transforms/transforms/django_core_handlers_wsgi.py
@@ -4,3 +4,4 @@ from django.core.handlers.wsgi import WSGIRequest as WSGIRequestOriginal
 class WSGIRequest(WSGIRequestOriginal):
     status_code = None
     content = ''
+    json = None


### PR DESCRIPTION
Changes to silence the warning: `Instance of 'WSGIRequest' has no 'json' member (no-member)`