### PR TITLE
Adding tests and transforms for DurationField

### DIFF
--- a/pylint_django/transforms/fields.py
+++ b/pylint_django/transforms/fields.py
@@ -45,6 +45,8 @@ def apply_type_shim(cls, context=None):  # noqa
         base_nodes = MANAGER.ast_from_module_name('datetime').lookup('time')
     elif cls.name == 'DateField':
         base_nodes = MANAGER.ast_from_module_name('datetime').lookup('date')
+    elif cls.name == 'DurationField':
+        base_nodes = MANAGER.ast_from_module_name('datetime').lookup('timedelta')
     elif cls.name == 'ManyToManyField':
         base_nodes = MANAGER.ast_from_module_name('django.db.models.query').lookup('QuerySet')
     elif cls.name in ('ImageField', 'FileField'):

--- a/pylint_django/transforms/transforms/django_db_models_fields.py
+++ b/pylint_django/transforms/transforms/django_db_models_fields.py
@@ -110,6 +110,12 @@ class TimeField(datetime.time, django_fields.TimeField):
             pass
 
 
+class DurationField(datetime.timedelta, django_fields.DurationField):
+    if PY3:
+        def __new__(cls, verbose_name=None, name=None, **kwargs):
+            pass
+
+
 # -------
 # misc
 

--- a/pylint_django/transforms/transforms/django_forms_fields.py
+++ b/pylint_django/transforms/transforms/django_forms_fields.py
@@ -101,7 +101,13 @@ class TimeField(datetime.time, django_fields.TimeField):
             pass
 
 
-    # --------
+class DurationField(datetime.timedelta, django_fields.DurationField):
+    if PY3:
+        def __new__(cls, *args, **kwargs):
+            pass
+
+
+# --------
 # choice
 
 class ChoiceField(object, django_fields.ChoiceField):

--- a/test/input/func_noerror_form_fields.py
+++ b/test/input/func_noerror_form_fields.py
@@ -15,6 +15,7 @@ class ManyFieldsForm(forms.Form):
     datetimefield = forms.DateTimeField(auto_now_add=True)
     datefield = forms.DateField(auto_now_add=True)
     decimalfield = forms.DecimalField(max_digits=5, decimal_places=2)
+    durationfield = forms.DurationField()
     emailfield = forms.EmailField()
     filefield = forms.FileField(name='test_file', upload_to='test')
     filepathfield = forms.FilePathField(path='/some/path')
@@ -59,6 +60,11 @@ class ManyFieldsForm(forms.Form):
 
     def decimalfield_tests(self):
         print(self.decimalfield.adjusted())
+
+    def durationfield_tests(self):
+        now = datetime.now()
+        print(now - self.durationfield)
+        print(self.durationfield.total_seconds())
 
     def filefield_tests(self):
         print(self.filefield)

--- a/test/input/func_noerror_model_fields.py
+++ b/test/input/func_noerror_model_fields.py
@@ -18,6 +18,7 @@ class LotsOfFieldsModel(models.Model):
     datetimefield = models.DateTimeField(auto_now_add=True)
     datefield = models.DateField(auto_now_add=True)
     decimalfield = models.DecimalField(max_digits=5, decimal_places=2)
+    durationfield = models.DurationField()
     emailfield = models.EmailField()
     filefield = models.FileField(name='test_file', upload_to='test')
     filepathfield = models.FilePathField()
@@ -68,6 +69,11 @@ class LotsOfFieldsModel(models.Model):
 
     def decimalfield_tests(self):
         print(self.decimalfield.compare(Decimal('1.4')))
+
+    def durationfield_tests(self):
+        now = datetime.now()
+        print(now - self.durationfield)
+        print(self.durationfield.total_seconds())
 
     def filefield_tests(self):
         print(self.filefield.file)


### PR DESCRIPTION
Fixes #95 

This PR adds support for [DurationField](https://docs.djangoproject.com/en/1.8/ref/models/fields/#durationfield), added in Django 1.8. DurationField acts like a `datetime.timedelta` object.

Minimal tests are included. Note that due to updates in PyLint, all tests fail, although tests pass after merging #98 into my local copy.