### PR TITLE
Support factory_boy's DjangoModelFactory Meta class

### DIFF
--- a/pylint_django/augmentations/__init__.py
+++ b/pylint_django/augmentations/__init__.py
@@ -407,6 +407,16 @@ def is_model_meta_subclass(node):
     return node_is_subclass(node.parent, *parents)
 
 
+def is_model_factory_meta_subclass(node):
+    """Checks that node is derivative of DjangoModelFactory class."""
+    if node.name != 'Meta' or not isinstance(node.parent, ClassDef):
+        return False
+
+    parents = ('factory.django.DjangoModelFactory',
+               '.DjangoModelFactory',)
+    return node_is_subclass(node.parent, *parents)
+
+
 def is_model_mpttmeta_subclass(node):
     """Checks that node is derivative of MPTTMeta class."""
     if node.name != 'MPTTMeta' or not isinstance(node.parent, ClassDef):
@@ -771,6 +781,12 @@ def apply_augmentations(linter):
     suppress_message(linter, _visit_class(NewStyleConflictChecker), 'old-style-class', is_model_mpttmeta_subclass)
     suppress_message(linter, _visit_class(ClassChecker), 'W0232', is_model_mpttmeta_subclass)
     suppress_message(linter, _leave_class(MisdesignChecker), 'too-few-public-methods', is_model_mpttmeta_subclass)
+
+    # factory_boy's DjangoModelFactory
+    suppress_message(linter, _visit_class(DocStringChecker), 'missing-docstring', is_model_factory_meta_subclass)
+    suppress_message(linter, _visit_class(NewStyleConflictChecker), 'old-style-class', is_model_factory_meta_subclass)
+    suppress_message(linter, _visit_class(ClassChecker), 'W0232', is_model_factory_meta_subclass)
+    suppress_message(linter, _leave_class(MisdesignChecker), 'too-few-public-methods', is_model_factory_meta_subclass)
 
     # ForeignKey and OneToOneField
     # Must update this in a thread safe way to support the parallel option on pylint (-j)


### PR DESCRIPTION
Added suppressions for [DjangoModelFactory](http://factoryboy.readthedocs.io/en/2.9.2/orms.html#the-djangomodelfactory-subclass).

E.g.

```
class UserFactory(factory.django.DjangoModelFactory):
    class Meta:
        model = 'myapp.User'

    username = 'john'
```