### PR TITLE
Don't transform DoesNotExist. Fixes #81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 * Update tests and require latest version of pylint (>=1.8), fixes
   [#53](https://github.com/landscapeio/pylint-django/issues/53),
   [#97](https://github.com/landscapeio/pylint-django/issues/97)
+* [#81](https://github.com/landscapeio/pylint-django/issues/81) Fix 'duplicate-except' false negative
+  for except blocks which catch the `DoesNotExist` exception.
 
 ## Version 0.7.4
 * [#88](https://github.com/landscapeio/pylint-django/pull/88) Fixed builds with Django 1.10 (thanks to [federicobond](https://github.com/federicobond))

--- a/pylint_django/transforms/transforms/django_db_models.py
+++ b/pylint_django/transforms/transforms/django_db_models.py
@@ -8,7 +8,6 @@ class Model(object):
     pk = None
 
     MultipleObjectsReturned = MultipleObjectsReturned
-    DoesNotExist = ObjectDoesNotExist
 
     save = lambda *a, **kw: None
     delete = lambda *a, **kw: None

--- a/test/input/func_noerror_duplicate_except_doesnotexist.py
+++ b/test/input/func_noerror_duplicate_except_doesnotexist.py
@@ -1,0 +1,23 @@
+"""
+Checks that Pylint does not complain about duplicate
+except blocks catching DoesNotExist exceptions:
+https://github.com/landscapeio/pylint-django/issues/81
+"""
+#  pylint: disable=missing-docstring
+from django.db import models
+
+
+class Book(models.Model):
+    name = models.CharField(max_length=100)
+
+
+class Author(models.Model):
+    name = models.CharField(max_length=100)
+
+def dummy_func():
+    try:
+        print("foo")
+    except Book.DoesNotExist:
+        print("bar")
+    except Author.DoesNotExist:
+        print("baz")


### PR DESCRIPTION
@gbataille, @sergafts can you try this patch and see if it works for you? 

@carlio from what I understand the transforms code adds a DoesNotExist attribute to the model class in such a way that it is the same type (ObjectDoesNotExist) which then triggers the original pylint warning reported in #81. I just have no idea if the fix won't break something else.